### PR TITLE
Use file from S3

### DIFF
--- a/lib/bing_ads_ruby_sdk/version.rb
+++ b/lib/bing_ads_ruby_sdk/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module BingAdsRubySdk
-  VERSION = "1.3.4"
+  VERSION = "1.3.5"
   DEFAULT_SDK_VERSION = :v13
 end


### PR DESCRIPTION
a Local token file cannot be on all servers, hence use S3 to store credentials in file